### PR TITLE
decompression performance improvements (~50%)

### DIFF
--- a/lz4.js
+++ b/lz4.js
@@ -96,9 +96,7 @@ function makeBuffer (size) {
 
 function sliceArray (array, start, end) {
   if (typeof array.buffer !== undefined) {
-    if (Uint8Array.prototype.subarray) {
-      return array.subarray(start, end);
-    }else if (Uint8Array.prototype.slice) {
+    if (Uint8Array.prototype.slice) {
       return array.slice(start, end);
     } else {
       // Uint8Array#slice polyfill.

--- a/lz4.js
+++ b/lz4.js
@@ -96,7 +96,9 @@ function makeBuffer (size) {
 
 function sliceArray (array, start, end) {
   if (typeof array.buffer !== undefined) {
-    if (Uint8Array.prototype.slice) {
+    if (Uint8Array.prototype.subarray) {
+      return array.subarray(start, end);
+    }else if (Uint8Array.prototype.slice) {
       return array.slice(start, end);
     } else {
       // Uint8Array#slice polyfill.
@@ -535,7 +537,6 @@ exports.decompress = function decompress (src, maxSize) {
   if (maxSize === undefined) {
     maxSize = exports.decompressBound(src);
   }
-
   dst = exports.makeBuffer(maxSize);
   size = exports.decompressFrame(src, dst);
 

--- a/lz4.js
+++ b/lz4.js
@@ -257,7 +257,7 @@ exports.decompressBlock = function decompressBlock (src, dst, sIndex, sLength, d
 
     // Copy match
     // prefer to use typedarray.copyWithin for larger matches
-    if (hasCopyWithin && mLength > 15) {
+    if (hasCopyWithin && mLength > 31) {
       dst.copyWithin(dIndex, dIndex - mOffset, dIndex - mOffset + mLength);
       dIndex += mLength;
     } else {

--- a/lz4.js
+++ b/lz4.js
@@ -181,7 +181,7 @@ exports.decompressBound = function decompressBound (src) {
     if (blockSize & bsUncompressed) {
       blockSize &= ~bsUncompressed;
       maxSize += blockSize;
-    } else {
+    } else if (blockSize > 0) {
       maxSize += maxBlockSize;
     }
 


### PR DESCRIPTION
Two main reasons for perf gains:
1. use [TypedArray.copyWithin ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin)
2. use [TypedArray.subarray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray) which reuses buffer instead of [TypedArray.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice) which makes a copy (and thus more work + GC)

Decompress a 12MB file, representing 100MB of raw data
orig: 230ms
copyWithin15+: 145ms
subarray: 130ms
copyWithin31+: 120ms
lz4cat: 70ms

